### PR TITLE
bump CI pinned Infrahub from 1.8.2 to 1.8.4

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: big
     timeout-minutes: 30
     env:
-      INFRAHUB_VERSION: 1.8.2
+      INFRAHUB_VERSION: 1.8.4
       INFRAHUB_URL: http://localhost:8000
       INFRAHUB_ADMIN_PASSWORD: ci-admin-password
       INFRAHUB_ADMIN_TOKEN: ci-admin-token

--- a/docs/compat.md
+++ b/docs/compat.md
@@ -6,7 +6,7 @@ series is inferred from the absence of breaking api changes in that range.
 
 | infrahub | infrahub upstream | notes                                |
 |----------|-------------------|--------------------------------------|
-| 0.2.x    | 1.1.x – 1.8.x     | CI pinned to 1.8.2                   |
+| 0.2.x    | 1.1.x – 1.8.x     | CI pinned to 1.8.4                   |
 | 0.1.x    | 1.1.x              | CI pinned to 1.1.0                   |
 
 older client releases have not been retroactively tested.


### PR DESCRIPTION
Bump the integration CI Infrahub image tag from 1.8.2 to 1.8.4 and update compat.md.

This is a patch-level upstream release. CI will confirm whether the smoke tests still pass against 1.8.4.

Closes #7

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._