### PR TITLE
add cargo-deny for license and advisory checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,19 @@ jobs:
         with:
           name: coverage-lcov
           path: lcov.info
+
+  deny:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+
+      - name: cargo-deny
+        run: cargo deny check

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,23 @@
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "BSD-2-Clause",
+    "ISC",
+    "0BSD",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
## What

Adds a `deny.toml` and a `deny` CI job that runs `cargo deny check`. Uses the same license allowlist and source restrictions as other cyberwitchery repos.

## Why

Catches license violations, known advisories, and unexpected crate sources in CI. Consistent with the setup in contextual-encoder, sbom-diff, unsafe-budget, and dd.

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._