### PR TITLE
ci: switch from Swatinem/rust-cache to kache, cache integration job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-clippy
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
@@ -44,7 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-test
       - run: cargo test --workspace
 
   doc:
@@ -55,7 +59,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-doc
       - run: cargo doc --workspace --no-deps
 
   deny:
@@ -80,7 +86,9 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: Swatinem/rust-cache@v2
+      - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-coverage
       - run: cargo llvm-cov --workspace --all-features --ignore-filename-regex 'src/bin/infrahub-codegen.rs|test-client/' --fail-under-lines 80 --lcov --output-path lcov.info
 
   success:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache cargo
+        uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-smoke
+
       - name: Download Infrahub docker compose
         run: |
           curl -sSfL \


### PR DESCRIPTION
Same pattern as netbox.rs PR #28 (warm test job 2m 59s → 34s, 100% hit rate).

Two changes:

1. **ci.yml**: replace `Swatinem/rust-cache@v2` with `kunobi-ninja/kache-action@v1` in clippy/test/doc/coverage jobs, per-job `cache-key-prefix` to avoid shared-key save races.

2. **integration.yml**: add a cache step (previously the smoke job rebuilt from scratch every run). `cache-key-prefix: kache-smoke`.