### PR TITLE
ci: run integration smoke job on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-clippy
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
@@ -44,7 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-test
       - run: cargo test --workspace
 
   doc:
@@ -55,7 +59,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-doc
       - run: cargo doc --workspace --no-deps
 
   deny:
@@ -80,7 +86,9 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: Swatinem/rust-cache@v2
+      - uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-coverage
       - run: cargo llvm-cov --workspace --all-features --ignore-filename-regex 'src/bin/infrahub-codegen.rs|test-client/' --fail-under-lines 80 --lcov --output-path lcov.info
 
   success:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache cargo
+        uses: kunobi-ninja/kache-action@v1
+        with:
+          cache-key-prefix: kache-smoke
+
       - name: Download Infrahub docker compose
         run: |
           curl -sSfL \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   smoke:
-    runs-on: big
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       INFRAHUB_VERSION: 1.9.6


### PR DESCRIPTION
Moves the `smoke` job in `integration.yml` off the `big` runner onto the free `ubuntu-latest`.

The generated `test-client` is ~100k lines and compiles comfortably within the 16 GB standard runner (public-repo `ubuntu-latest` is 4-core/16 GB — the recorded gen-crate OOM was at 6 GB, well under that). The `big` (32 GB) runner is unnecessary for this job.

Verified on `ci/kache` via `workflow_dispatch`: [run 26956900536](https://github.com/cyberwitchery/infrahub.rs/actions/runs/26956900536) — `smoke` green in 5m0s, including gen-client compile, codegen up-to-date check, and smoke tests.